### PR TITLE
Set initialized to true after init().

### DIFF
--- a/src/main.mo
+++ b/src/main.mo
@@ -77,6 +77,7 @@ shared({ caller = hub }) actor class Nft() = this {
         assert not INITALIZED and caller == hub;
         contractOwners := Array.append(contractOwners, owners);
         CONTRACT_METADATA := metadata;
+        INITALIZED := true;
     };
 
     public query func getMetadata() : async NftTypes.ContractMetadata {


### PR DESCRIPTION
`INITALIZED` is used to check whether the hub is already initialized. 
If not `init()` can be called, yet it is never set to `true` during the initialization process.